### PR TITLE
Docker Install - 2018 Near Surface Geophysics Workshop

### DIFF
--- a/build/singleuser/Dockerfile.wine
+++ b/build/singleuser/Dockerfile.wine
@@ -1,0 +1,64 @@
+FROM cuahsi/singleuser
+MAINTAINER Tony Castronova <acastronova@cuahsi.org>
+
+# installations for 2018 Near Surface Geophysics
+# wine:
+USER root
+
+RUN buildDeps='wget' \
+&& set -x \
+&& cd /tmp \
+&& apt update \
+&& apt-get install -y apt-transport-https $buildDeps --no-install-recommends \
+&& dpkg --add-architecture i386 \
+&& wget -nc https://dl.winehq.org/wine-builds/Release.key \
+&& apt-key add Release.key \
+&& apt-add-repository https://dl.winehq.org/wine-builds/ubuntu/ \
+&& apt update \
+&& apt-get install -y --no-install-recommends winehq-stable \
+&& apt-get purge -y --auto-remove $buildDeps \
+&& rm -rf /var/lib/apt/lists/* \
+&& rm -rf /tmp/*
+
+# R2:
+RUN buildDeps='unrar wget' \
+&& set -x \
+&& apt-get update \
+&& apt-get install -y $buildDeps --no-install-recommends \
+&& mkdir /tmp/R2 \
+&& cd /tmp/R2 \
+&& wget http://www.es.lancs.ac.uk/people/amb/Freeware/R2/R2.rar \
+&& unrar e -y R2.rar \
+&& chmod +x R2.exe \
+&& mv R2.exe /usr/local/bin \
+&& apt-get purge -y --auto-remove $buildDeps \
+&& rm -rf /var/lib/apt/lists/* \
+&& rm -rf /tmp/*
+
+# gmsh:
+RUN buildDeps='wget' \
+&& set -x \
+&& apt-get update \
+&& apt-get install -y $buildDeps --no-install-recommends \
+&& cd /tmp \
+&& wget http://gmsh.info/bin/Linux/gmsh-4.0.1-Linux64.tgz \
+&& tar -xzf gmsh-4.0.1-Linux64.tgz \
+&& cp -r gmsh-4.0.1-Linux64/share/doc/gmsh /usr/local/share/doc \
+&& cp -r gmsh-4.0.1-Linux64/share/man/man1/gmsh.1 /usr/local/share/man \
+&& cp -r gmsh-4.0.1-Linux64/bin/* /usr/local/bin \
+&& apt-get purge -y --auto-remove $buildDeps \
+&& rm -rf /var/lib/apt/lists/* \
+&& rm -rf /tmp/*
+
+#pyres
+RUN cd /tmp \
+&& git clone https://github.com/kbefus/pyres.git \
+&& cd /tmp/pyres \
+&& /opt/conda/bin/python setup.py install \
+&& rm -rf /tmp/*
+
+RUN chown -R jovyan:users /home/jovyan
+USER jovyan
+
+ENV WINEPREFIX="/home/jovyan/.wine"
+RUN wineboot


### PR DESCRIPTION
Library installations for the 2018 Near Surface Geophysics Workshop, see issue https://github.com/hydroshare/hydroshare-jupyterhub/issues/126

Consists of the following libraries:
- wine, https://wiki.winehq.org/Ubuntu
- R2, http://www.es.lancs.ac.uk/people/amb/Freeware/R2/R2.htm
- gmsh, http://gmsh.info/